### PR TITLE
Add mobile support

### DIFF
--- a/src/components/physics/bodies/letters.tsx
+++ b/src/components/physics/bodies/letters.tsx
@@ -44,7 +44,7 @@ export const LetterElement = (props: IMatterLetter) => {
         }
     })
 
-    const accent = LetterAccentElement({y: y - size * 1.6, x, letter, size: size})
+    const accent = LetterAccentElement({y: y - size * 1.4, x, letter, size: size})
 
     return{
         ...props,
@@ -68,8 +68,8 @@ export const LetterAccentElement = (props: any) => {
             fillStyle: '#000',
             sprite: {
                 texture: accent.name !== 'acute' ? require(`../sprites/${accent.name}.png`) : false,
-                xScale: interpolate(size,14,22,0.3,0.5),
-                yScale: interpolate(size,14,22,0.3,0.5)
+                xScale: interpolate(size,12,26,0.2,0.5),
+                yScale: interpolate(size,12,26,0.2,0.5)
             }
         }
     })

--- a/src/components/physics/bodies/letters.tsx
+++ b/src/components/physics/bodies/letters.tsx
@@ -1,5 +1,6 @@
 //@ts-ignore
 import { Bodies, Body } from 'matter-js'
+import { interpolate } from '../../../logic/utils'
 const ACCENT_HEIGHT = 7
 const LETTER_ACCENT = [
     {
@@ -27,7 +28,7 @@ const getLetterSprite = (letter: string) => {
 }
 
 export const LetterElement = (props: IMatterLetter) => {
-    const {x, y, size, letter, inertia = 99999999, restitution = 0.1} = props
+    const {x, y, size, letter, inertia = 99999999, restitution = 0.1, scale = 1} = props
     const letterWithoutAccent = letter.normalize("NFD").replace(/\p{Diacritic}/gu, "")
 
     const body = Bodies.circle(x, y, size, {
@@ -37,13 +38,13 @@ export const LetterElement = (props: IMatterLetter) => {
         render: {
             sprite:{
                 texture: getLetterSprite(letterWithoutAccent),
-                xScale: 0.25,
-                yScale: 0.25
+                xScale: scale,
+                yScale: scale
             }
         }
     })
 
-    const accent = LetterAccentElement({y: y - size * 1.7, x, letter, size: size})
+    const accent = LetterAccentElement({y: y - size * 1.6, x, letter, size: size})
 
     return{
         ...props,
@@ -67,8 +68,8 @@ export const LetterAccentElement = (props: any) => {
             fillStyle: '#000',
             sprite: {
                 texture: accent.name !== 'acute' ? require(`../sprites/${accent.name}.png`) : false,
-                xScale: 0.5,
-                yScale: 0.5
+                xScale: interpolate(size,14,22,0.3,0.5),
+                yScale: interpolate(size,14,22,0.3,0.5)
             }
         }
     })

--- a/src/components/physics/bodies/types.d.ts
+++ b/src/components/physics/bodies/types.d.ts
@@ -21,4 +21,5 @@ interface IMatterLetter {
     letter: string
     restitution?: number,
     inertia?: number
+    scale?: number
 }

--- a/src/components/physics/engines/animation-engine.tsx
+++ b/src/components/physics/engines/animation-engine.tsx
@@ -1,5 +1,5 @@
 //@ts-ignore
-import {Engine, Events, Render, Runner, Composite, Mouse, MouseConstraint} from 'matter-js'
+import {Engine, Events, Body, Render, Runner, Composite, Mouse, MouseConstraint} from 'matter-js'
 import { Circle } from '../bodies/circles'
 import { FloorElement } from '../bodies/floor'
 import { BounceEllement } from './bounce-text'
@@ -75,8 +75,9 @@ export const AnimationEngine = (props: IAnimationCanvas): IAnimationCanvasReturn
             Composite.add(engine.world, circle)
 
             window.addEventListener('deviceorientation', (event) => {
-                circle.position.x = scale(event.gamma, [-90,90], [0,width])
-                circle.position.y = scale(event.beta, [-10,110], [0,height])
+                let x = scale(event.gamma, [-90,90], [0,width])
+                let y = scale(event.beta, [-10,110], [0,height])
+                Body.setPosition(circle, {x, y})
                 callback(event)
               }, true)
         },

--- a/src/components/physics/engines/animation-engine.tsx
+++ b/src/components/physics/engines/animation-engine.tsx
@@ -72,10 +72,10 @@ export const AnimationEngine = (props: IAnimationCanvas): IAnimationCanvasReturn
             };
 
             window.addEventListener('deviceorientation', (event) => {
-                let x = scale(event.gamma, [-60,60], [-1,1])
-                let y = scale(event.beta, [20,60], [-1,1])
+                let x = scale(event.gamma, [-90,90], [-0.3,0.3])
+                // let y = scale(event.beta, [20,60], [-1,1])
                 engine.gravity.x = x
-                engine.gravity.y = y
+                // engine.gravity.y = y
 
                 if(callback)
                     callback(event)

--- a/src/components/physics/engines/animation-engine.tsx
+++ b/src/components/physics/engines/animation-engine.tsx
@@ -59,6 +59,27 @@ export const AnimationEngine = (props: IAnimationCanvas): IAnimationCanvasReturn
             });
             Composite.add(engine.world, [mouseConstraint])
         },
+        addGyroscopeConstraint: (callback) => {
+            const scale = (inputY:any, yRange:any, xRange:any) => {
+                const [xMin, xMax] = xRange;
+                const [yMin, yMax] = yRange;
+              
+                const percent = (inputY - yMin) / (yMax - yMin);
+                const outputX = percent * (xMax - xMin) + xMin;
+              
+                return outputX;
+            };
+
+        
+            const circle = Circle({x:100, y:100, radius: 21, options:{isStatic: true}})
+            Composite.add(engine.world, circle)
+
+            window.addEventListener('deviceorientation', (event) => {
+                circle.position.x = scale(event.gamma, [-90,90], [0,width])
+                circle.position.y = scale(event.beta, [-180,180], [0,height])
+                callback(event)
+              }, true)
+        },
         addFloor: () => {
             const floor = FloorElement({width: width, height: 80, x: width/2, y:height+40})
             Composite.add(engine.world, [floor])

--- a/src/components/physics/engines/animation-engine.tsx
+++ b/src/components/physics/engines/animation-engine.tsx
@@ -75,8 +75,8 @@ export const AnimationEngine = (props: IAnimationCanvas): IAnimationCanvasReturn
             Composite.add(engine.world, circle)
 
             window.addEventListener('deviceorientation', (event) => {
-                let x = scale(event.gamma, [-90,90], [0,width])
-                let y = scale(event.beta, [-10,110], [0,height])
+                let x = scale(event.gamma, [-60,60], [0,width])
+                let y = scale(event.beta, [20,60], [0,height])
                 Body.setPosition(circle, {x, y})
                 callback(event)
               }, true)

--- a/src/components/physics/engines/animation-engine.tsx
+++ b/src/components/physics/engines/animation-engine.tsx
@@ -22,6 +22,7 @@ export const AnimationEngine = (props: IAnimationCanvas): IAnimationCanvasReturn
     const runner = Runner.create()
     const render = Render.create(renderConfig)
     const bounceEllement = BounceEllement(engine)
+    let mouse, mouseConstraint: any = undefined
 
     return {
         engine,
@@ -47,7 +48,7 @@ export const AnimationEngine = (props: IAnimationCanvas): IAnimationCanvasReturn
             return Circle(props)
         },
         addMouseConstraint: ({stiffness, visible}: {stiffness?: number, visible?: boolean} = {}) => {
-            var mouse = Mouse.create(render.canvas),
+            mouse = Mouse.create(render.canvas)
             mouseConstraint = MouseConstraint.create(engine, {
                 mouse: mouse,
                 constraint: {
@@ -89,6 +90,9 @@ export const AnimationEngine = (props: IAnimationCanvas): IAnimationCanvasReturn
         },
         onAfterUpdate: (callback: any) => {
             Events.on(engine, 'afterUpdate', callback);
-        }
+        },
+        onTouchEnd: (callback) => {
+            Events.on(mouseConstraint, 'mouseup', callback);
+        },
     }
 }

--- a/src/components/physics/engines/animation-engine.tsx
+++ b/src/components/physics/engines/animation-engine.tsx
@@ -70,15 +70,14 @@ export const AnimationEngine = (props: IAnimationCanvas): IAnimationCanvasReturn
                 return outputX;
             };
 
-        
-            const circle = Circle({x:100, y:100, radius: 21, options:{isStatic: true}})
-            Composite.add(engine.world, circle)
-
             window.addEventListener('deviceorientation', (event) => {
-                let x = scale(event.gamma, [-60,60], [0,width])
-                let y = scale(event.beta, [20,60], [0,height])
-                Body.setPosition(circle, {x, y})
-                callback(event)
+                let x = scale(event.gamma, [-60,60], [-1,1])
+                let y = scale(event.beta, [20,60], [-1,1])
+                engine.gravity.x = x
+                engine.gravity.y = y
+
+                if(callback)
+                    callback(event)
               }, true)
         },
         addFloor: () => {

--- a/src/components/physics/engines/animation-engine.tsx
+++ b/src/components/physics/engines/animation-engine.tsx
@@ -76,7 +76,7 @@ export const AnimationEngine = (props: IAnimationCanvas): IAnimationCanvasReturn
 
             window.addEventListener('deviceorientation', (event) => {
                 circle.position.x = scale(event.gamma, [-90,90], [0,width])
-                circle.position.y = scale(event.beta, [-180,180], [0,height])
+                circle.position.y = scale(event.beta, [-10,110], [0,height])
                 callback(event)
               }, true)
         },

--- a/src/components/physics/engines/animation-engine.tsx
+++ b/src/components/physics/engines/animation-engine.tsx
@@ -1,5 +1,6 @@
 //@ts-ignore
 import {Engine, Events, Render, Runner, Composite, Mouse, MouseConstraint} from 'matter-js'
+import { interpolate } from '../../../logic/utils'
 import { Circle } from '../bodies/circles'
 import { FloorElement } from '../bodies/floor'
 import { BounceEllement } from './bounce-text'
@@ -61,18 +62,8 @@ export const AnimationEngine = (props: IAnimationCanvas): IAnimationCanvasReturn
             Composite.add(engine.world, [mouseConstraint])
         },
         addGyroscopeConstraint: (callback) => {
-            const scale = (inputY:any, yRange:any, xRange:any) => {
-                const [xMin, xMax] = xRange;
-                const [yMin, yMax] = yRange;
-              
-                const percent = (inputY - yMin) / (yMax - yMin);
-                const outputX = percent * (xMax - xMin) + xMin;
-              
-                return outputX;
-            };
-
             window.addEventListener('deviceorientation', (event) => {
-                let x = scale(event.gamma, [-90,90], [-0.3,0.3])
+                let x = interpolate(event.gamma,-90,90, -0.3,0.3)
                 // let y = scale(event.beta, [20,60], [-1,1])
                 engine.gravity.x = x
                 // engine.gravity.y = y
@@ -85,8 +76,8 @@ export const AnimationEngine = (props: IAnimationCanvas): IAnimationCanvasReturn
             const floor = FloorElement({width: width, height: 80, x: width/2, y:height+40})
             Composite.add(engine.world, [floor])
         },
-        addBounceText: ({text, size}) => {
-            bounceEllement.addText({text, letterSize: size, width, height})
+        addBounceText: ({text, size, scale}) => {
+            bounceEllement.addText({text, letterSize: size, width, height, scale})
         },
         onAfterUpdate: (callback: any) => {
             Events.on(engine, 'afterUpdate', callback);

--- a/src/components/physics/engines/animation-engine.tsx
+++ b/src/components/physics/engines/animation-engine.tsx
@@ -1,5 +1,5 @@
 //@ts-ignore
-import {Engine, Events, Body, Render, Runner, Composite, Mouse, MouseConstraint} from 'matter-js'
+import {Engine, Events, Render, Runner, Composite, Mouse, MouseConstraint} from 'matter-js'
 import { Circle } from '../bodies/circles'
 import { FloorElement } from '../bodies/floor'
 import { BounceEllement } from './bounce-text'

--- a/src/components/physics/engines/bounce-text.tsx
+++ b/src/components/physics/engines/bounce-text.tsx
@@ -1,6 +1,6 @@
 //@ts-ignore
 import {Composite} from 'matter-js'
-import { interpolate, SCREENS_RANGE } from '../../../logic/utils'
+import { interpolate } from '../../../logic/utils'
 import { LetterElement } from '../bodies/letters'
 import { Sling } from '../constraints/sling'
 

--- a/src/components/physics/engines/bounce-text.tsx
+++ b/src/components/physics/engines/bounce-text.tsx
@@ -1,5 +1,6 @@
 //@ts-ignore
 import {Composite} from 'matter-js'
+import { interpolate, SCREENS_RANGE } from '../../../logic/utils'
 import { LetterElement } from '../bodies/letters'
 import { Sling } from '../constraints/sling'
 
@@ -7,8 +8,6 @@ const sanitizeText = (text: string) => String(text).toLocaleLowerCase()
 
 export const BounceEllement = (animationEngine: any):IBounceTextAnimationReturn => {
     const letterChain = Composite.create({label: 'letter chain'})
-    const Y_SEPARATION = 100
-    const X_SEPARATION = 38
     const MAX_LINES = 3
 
     const resetTextOnCanvas = () => {
@@ -16,7 +15,11 @@ export const BounceEllement = (animationEngine: any):IBounceTextAnimationReturn 
         Composite.remove(animationEngine.world, letterChain)
     }
 
-    const getLetterPosition = ({width, height, letterSize, i, text, wordIndex}: any) => ({
+    const getLetterPosition = ({width, height, letterSize, i, text, wordIndex}: any) => {
+    const Y_SEPARATION = interpolate(letterSize, 14, 22, 80, 100)
+    const X_SEPARATION = interpolate(letterSize, 14, 20, 24, 40)
+
+    return{
         top: {
             x: (letterSize * 2) + (i * (letterSize * X_SEPARATION)), 
             y: (letterSize * 2)
@@ -25,11 +28,12 @@ export const BounceEllement = (animationEngine: any):IBounceTextAnimationReturn 
             x: ((width / 2) - ((text.length) * ((letterSize + X_SEPARATION) / 2))) + ((letterSize + X_SEPARATION) * i) + ((letterSize + X_SEPARATION )/ 2),
             y: ((height / 2) - (((text.split(' ').length * ((letterSize + Y_SEPARATION) / 2)))) + (wordIndex * ((letterSize + Y_SEPARATION) / 2)))
         }
-    })
+    }
+}
 
     return({
         letterChain,
-        addText: ({text, letterSize = 32, position = 'center', width, height}) => {
+        addText: ({text, letterSize = 32, position = 'center', width, height, scale}) => {
             resetTextOnCanvas()
             text = sanitizeText(text)
             let words = text.split(' ')
@@ -45,7 +49,7 @@ export const BounceEllement = (animationEngine: any):IBounceTextAnimationReturn 
                 for (let i = 0; i < word.length; i++ ){
                     if(word[i] === ' ') continue
                     const {x, y}: any = getLetterPosition({width, height, text: word, letterSize, i, wordIndex})[position]
-                    const letter = LetterElement({x, y, size: letterSize, letter: word[i]})
+                    const letter = LetterElement({x, y, size: letterSize, letter: word[i], scale})
                     const sling = Sling({x, y, bodyB: letter.body, length: 0})
 
                     if(letter.accent){

--- a/src/components/physics/engines/types.d.ts
+++ b/src/components/physics/engines/types.d.ts
@@ -15,8 +15,9 @@ interface IAnimationCanvasReturn{
     addFloor: () => void
     addBounceText: ({text, size}: {text: string, size: number}) => void
     addMouseConstraint: () => void
-    addGyroscopeConstraint: (callback: (event: any) => void) => void
+    addGyroscopeConstraint: (callback?: (event: any) => void) => void
     onAfterUpdate: (callback?: any) => void
+    onTouchEnd: (callback?: any) => void
     engine: any
     world: any
     width: number,

--- a/src/components/physics/engines/types.d.ts
+++ b/src/components/physics/engines/types.d.ts
@@ -15,6 +15,7 @@ interface IAnimationCanvasReturn{
     addFloor: () => void
     addBounceText: ({text, size}: {text: string, size: number}) => void
     addMouseConstraint: () => void
+    addGyroscopeConstraint: (callback: (event: any) => void) => void
     onAfterUpdate: (callback?: any) => void
     engine: any
     world: any

--- a/src/components/physics/engines/types.d.ts
+++ b/src/components/physics/engines/types.d.ts
@@ -13,7 +13,7 @@ interface IAnimationCanvasReturn{
     composite: ({label, id}: {label: string, id?: number}) => any
     circle: (props: ICircleProps) => any
     addFloor: () => void
-    addBounceText: ({text, size}: {text: string, size: number}) => void
+    addBounceText: ({text, size, scale}: {text: string, size: number, scale?: number}) => void
     addMouseConstraint: () => void
     addGyroscopeConstraint: (callback?: (event: any) => void) => void
     onAfterUpdate: (callback?: any) => void
@@ -26,7 +26,7 @@ interface IAnimationCanvasReturn{
 
 interface IBounceTextAnimationReturn {
     letterChain: any,
-    addText: ({}: {text: string, letterSize?: number, position?: 'top'| 'center', width: number, height: number}) => void
+    addText: ({}: {text: string, letterSize?: number, position?: 'top'| 'center', width: number, height: number, scale?: number}) => void
 }
 
 interface IRandomShapesGeneratorReturn {

--- a/src/logic/generator/hook.tsx
+++ b/src/logic/generator/hook.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react"
 import { RandomGenerator } from "./controller"
 
-export const useRandomGenerator = () => {
+export const useRandomGenerator = (initialPhrase: string) => {
     const randomGenerator = RandomGenerator()
     const [colorPallete, setColorPalette] = useState(randomGenerator.getColorPallete())
-    const [theme, setTheme] = useState('Click para gerar')
+    const [theme, setTheme] = useState(initialPhrase)
 
     const generateTheme = () => {
         setTheme(randomGenerator.getTheme())

--- a/src/logic/utils.ts
+++ b/src/logic/utils.ts
@@ -1,3 +1,9 @@
 export const getRandomArbitrary = (min: number, max: number) => Number.parseInt((Math.random() * ((max + 1) - min) + min))
 
 export const getRandomListItem = (list: any) => list[getRandomArbitrary(0,(list.length - 1))]
+
+export const interpolate = (value: number | any = 0, low1: number, high1: number, low2: number, high2: number) => {
+    return low2 + (high2 - low2) * (value - low1) / (high1 - low1);
+}
+
+export const SCREENS_RANGE: [number,number] = [200,3000]

--- a/src/pages/ThemeGenerator/controller.tsx
+++ b/src/pages/ThemeGenerator/controller.tsx
@@ -3,6 +3,9 @@ import { AnimationEngine } from "../../components/physics/engines/animation-engi
 export const getAnimationEngine = ({width, height, canvasRef, boxRef}: IAnimationCanvas) => {
     let newAnimationEngine = AnimationEngine({width, height, canvasRef, boxRef})
     newAnimationEngine.addMouseConstraint()
+    newAnimationEngine.addGyroscopeConstraint(e => {
+        
+    })
     newAnimationEngine.addFloor()
     newAnimationEngine.run()
 

--- a/src/pages/ThemeGenerator/controller.tsx
+++ b/src/pages/ThemeGenerator/controller.tsx
@@ -3,9 +3,7 @@ import { AnimationEngine } from "../../components/physics/engines/animation-engi
 export const getAnimationEngine = ({width, height, canvasRef, boxRef}: IAnimationCanvas) => {
     let newAnimationEngine = AnimationEngine({width, height, canvasRef, boxRef})
     newAnimationEngine.addMouseConstraint()
-    newAnimationEngine.addGyroscopeConstraint(e => {
-        
-    })
+    newAnimationEngine.addGyroscopeConstraint()
     newAnimationEngine.addFloor()
     newAnimationEngine.run()
 

--- a/src/pages/ThemeGenerator/index.tsx
+++ b/src/pages/ThemeGenerator/index.tsx
@@ -7,6 +7,7 @@ import './style.scss'
 
 const ThemeGenerator = () => {
     const LETTER_SIZE = 20
+    const INITIAL_PHRASE = 'Click para gerar'
     const WIDTH = document.documentElement.clientWidth
     const HEIGHT = document.documentElement.clientHeight
 
@@ -15,10 +16,13 @@ const ThemeGenerator = () => {
     const colorPalleteLabel = useRef(null)
 
     const [animationEngine, setAnimationEngine] = useState<any>()
-    const {theme, colorPallete, generateTheme} = useRandomGenerator()
+    const {theme, colorPallete, generateTheme} = useRandomGenerator('Click para gerar')
 
     useLayoutEffect(() => {
       const newAnimationEngine = getAnimationEngine({width: WIDTH, height: HEIGHT, canvasRef, boxRef})
+      newAnimationEngine.onTouchEnd(() => {
+        generateTheme()
+      })
       setAnimationEngine(newAnimationEngine)
     }, [WIDTH, HEIGHT])
 
@@ -39,17 +43,16 @@ const ThemeGenerator = () => {
     }, [animationEngine, colorPalleteLabel, WIDTH])
 
     useEffect(()=>{
-      if(!animationEngine) return
-      animationEngine.addBounceText({text: theme, size: LETTER_SIZE})
+      if(animationEngine)
+        animationEngine.addBounceText({text: theme, size: LETTER_SIZE})
+        
+      if(theme !== INITIAL_PHRASE)
+        updateShapes(colorPallete)
     }, [theme, animationEngine])
 
-    const onChangeTheme = () => {
-      generateTheme()
-      updateShapes(colorPallete)
-    }
-      
     return (
-        <div id='theme-generator-screen' ref={boxRef} onClick={onChangeTheme}>
+        <div id='theme-generator-screen' ref={boxRef}>
+          <canvas ref={canvasRef}/>
           <div className='screen-labels'>
             <h1 className='theme-label'>Seu tema é:</h1>
             <span className='theme-empty-space'></span>
@@ -57,7 +60,6 @@ const ThemeGenerator = () => {
               paleta de cores
             </h2>
           </div>
-          <canvas ref={canvasRef} />
         </div>
       )
 }

--- a/src/pages/ThemeGenerator/index.tsx
+++ b/src/pages/ThemeGenerator/index.tsx
@@ -40,12 +40,6 @@ const ThemeGenerator = () => {
     }, [animationEngine, colorPalleteLabel, WIDTH])
 
     useEffect(()=>{
-      window.addEventListener('deviceorientation', () => {
-        setOrientation('upa')
-      }, true)
-    }, [])
-
-    useEffect(()=>{
       if(!animationEngine) return
       animationEngine.addBounceText({text: theme, size: LETTER_SIZE})
     }, [theme, animationEngine])

--- a/src/pages/ThemeGenerator/index.tsx
+++ b/src/pages/ThemeGenerator/index.tsx
@@ -16,7 +16,6 @@ const ThemeGenerator = () => {
 
     const [animationEngine, setAnimationEngine] = useState<any>()
     const {theme, colorPallete, generateTheme} = useRandomGenerator()
-    const [orientation] = useState('0:0')
 
     useLayoutEffect(() => {
       const newAnimationEngine = getAnimationEngine({width: WIDTH, height: HEIGHT, canvasRef, boxRef})
@@ -52,7 +51,7 @@ const ThemeGenerator = () => {
     return (
         <div id='theme-generator-screen' ref={boxRef} onClick={onChangeTheme}>
           <div className='screen-labels'>
-            <h1 className='theme-label'>Seu tema é ({orientation})</h1>
+            <h1 className='theme-label'>Seu tema é:</h1>
             <span className='theme-empty-space'></span>
             <h2 id='color-pallete-label' className='theme-color-pallete-label' ref={colorPalleteLabel}>
               paleta de cores

--- a/src/pages/ThemeGenerator/index.tsx
+++ b/src/pages/ThemeGenerator/index.tsx
@@ -16,6 +16,7 @@ const ThemeGenerator = () => {
 
     const [animationEngine, setAnimationEngine] = useState<any>()
     const {theme, colorPallete, generateTheme} = useRandomGenerator()
+    const [orientation, setOrientation] = useState('0:0')
 
     useLayoutEffect(() => {
       const newAnimationEngine = getAnimationEngine({width: WIDTH, height: HEIGHT, canvasRef, boxRef})
@@ -39,6 +40,12 @@ const ThemeGenerator = () => {
     }, [animationEngine, colorPalleteLabel, WIDTH])
 
     useEffect(()=>{
+      window.addEventListener('deviceorientation', () => {
+        setOrientation('upa')
+      }, true)
+    }, [])
+
+    useEffect(()=>{
       if(!animationEngine) return
       animationEngine.addBounceText({text: theme, size: LETTER_SIZE})
     }, [theme, animationEngine])
@@ -51,7 +58,7 @@ const ThemeGenerator = () => {
     return (
         <div id='theme-generator-screen' ref={boxRef} onClick={onChangeTheme}>
           <div className='screen-labels'>
-            <h1 className='theme-label'>Seu tema é</h1>
+            <h1 className='theme-label'>Seu tema é ({orientation})</h1>
             <span className='theme-empty-space'></span>
             <h2 id='color-pallete-label' className='theme-color-pallete-label' ref={colorPalleteLabel}>
               paleta de cores

--- a/src/pages/ThemeGenerator/index.tsx
+++ b/src/pages/ThemeGenerator/index.tsx
@@ -10,8 +10,8 @@ const ThemeGenerator = () => {
     const INITIAL_PHRASE = 'Click para gerar'
     const WIDTH = document.documentElement.clientWidth
     const HEIGHT = document.documentElement.clientHeight
-    const LETTER_SIZE = interpolate(WIDTH, SCREENS_RANGE[0], SCREENS_RANGE[1], 14, 22)
-    const LETTER_SCALE = interpolate(LETTER_SIZE, 14, 22, 0.15, 0.22)
+    const LETTER_SIZE = interpolate(WIDTH, SCREENS_RANGE[0], SCREENS_RANGE[1], 12, 26)
+    const LETTER_SCALE = interpolate(LETTER_SIZE, 14, 20, 0.11, 0.20)
 
     const boxRef = useRef(null)
     const canvasRef = useRef(null)

--- a/src/pages/ThemeGenerator/index.tsx
+++ b/src/pages/ThemeGenerator/index.tsx
@@ -2,14 +2,16 @@ import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import { ColorPalleteEllement } from '../../components/physics/engines/color-pallete'
 import { RandomShapesGenerator } from '../../components/physics/engines/random-shapes'
 import { useRandomGenerator } from '../../logic/generator/hook'
+import { interpolate, SCREENS_RANGE } from '../../logic/utils'
 import { getAnimationEngine } from './controller'
 import './style.scss'
 
 const ThemeGenerator = () => {
-    const LETTER_SIZE = 20
     const INITIAL_PHRASE = 'Click para gerar'
     const WIDTH = document.documentElement.clientWidth
     const HEIGHT = document.documentElement.clientHeight
+    const LETTER_SIZE = interpolate(WIDTH, SCREENS_RANGE[0], SCREENS_RANGE[1], 14, 22)
+    const LETTER_SCALE = interpolate(LETTER_SIZE, 14, 22, 0.15, 0.22)
 
     const boxRef = useRef(null)
     const canvasRef = useRef(null)
@@ -19,10 +21,14 @@ const ThemeGenerator = () => {
     const {theme, colorPallete, generateTheme} = useRandomGenerator('Click para gerar')
 
     useLayoutEffect(() => {
-      const newAnimationEngine = getAnimationEngine({width: WIDTH, height: HEIGHT, canvasRef, boxRef})
-      newAnimationEngine.onTouchEnd(() => {
-        generateTheme()
+      const newAnimationEngine = getAnimationEngine({
+        width: WIDTH,
+        height: HEIGHT,
+        canvasRef,
+        boxRef
       })
+
+      newAnimationEngine.onTouchEnd(generateTheme)
       setAnimationEngine(newAnimationEngine)
     }, [WIDTH, HEIGHT])
 
@@ -44,7 +50,7 @@ const ThemeGenerator = () => {
 
     useEffect(()=>{
       if(animationEngine)
-        animationEngine.addBounceText({text: theme, size: LETTER_SIZE})
+        animationEngine.addBounceText({text: theme, size: LETTER_SIZE, scale: LETTER_SCALE})
         
       if(theme !== INITIAL_PHRASE)
         updateShapes(colorPallete)

--- a/src/pages/ThemeGenerator/index.tsx
+++ b/src/pages/ThemeGenerator/index.tsx
@@ -16,7 +16,7 @@ const ThemeGenerator = () => {
 
     const [animationEngine, setAnimationEngine] = useState<any>()
     const {theme, colorPallete, generateTheme} = useRandomGenerator()
-    const [orientation, setOrientation] = useState('0:0')
+    const [orientation] = useState('0:0')
 
     useLayoutEffect(() => {
       const newAnimationEngine = getAnimationEngine({width: WIDTH, height: HEIGHT, canvasRef, boxRef})


### PR DESCRIPTION
Added some modifications to also works on mobile gadgets

Fixes:
- Added `onTouchEnd` event listener because the canvas was in front of all elements, blocking the `onClick` on the `DIV`
- Added the `addGyroscopeConstraint` listener to move the circles according to the device orientation